### PR TITLE
updates for Python 3.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: python
 python:
+    - "3.6"
+    - "3.5"
     - "3.4"
     - "3.3"
     - "3.2"
     - "2.7"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
 install:
     - python setup.py develop
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ install:
     - python setup.py develop
 script:
     - python -m unittest discover
+    - aqi -l

--- a/aqi/algos/__init__.py
+++ b/aqi/algos/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pkgutil
+import importlib
 
 
 def get_algo(algo_mod):
@@ -28,11 +29,11 @@ def list_algos():
     _algos = []
     algos_pkg = 'aqi.algos'
 
-    package = __import__(algos_pkg, fromlist=[algos_pkg])
+    package = importlib.import_module(algos_pkg)
     for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
         if ispkg is False and modname != 'base':
             algo_mod = '.'.join([algos_pkg, modname])
-            mod = __import__(algo_mod, fromlist=[algo_mod])
+            mod = importlib.import_module(algo_mod)
             _aqi = mod.AQI()
             _algos.append((mod.__name__, _aqi.list_pollutants()))
     return _algos


### PR DESCRIPTION
* make command line tool (`aqi`) work on Python 3.3 and up, and verify this in Travis
* add Python 3.5/3.6/3.7 to the Travis testing matrix