### PR TITLE
Fix IndexError when concentration is outside of EPA range

### DIFF
--- a/aqi/algos/base.py
+++ b/aqi/algos/base.py
@@ -76,8 +76,14 @@ class PiecewiseAQI(BaseAQI):
         _cc = Decimal(cc).quantize(self.piecewise['prec'][elem],
                                    rounding=ROUND_DOWN)
 
-        # define breakpoints for this pollutant at this contentration
+        # define breakpoints for this pollutant at this concentration
         bps = self.piecewise['bp'][elem]
+        bplo_min = bps[0][0]
+        if _cc < bplo_min:
+            return Decimal(self.piecewise['aqi'][0][0])
+        bphi_max = bps[-1][1]
+        if _cc > bphi_max:
+            return Decimal(self.piecewise['aqi'][-1][1])
         bplo = None
         bphi = None
         idx = 0


### PR DESCRIPTION
Hi @hrbonz 

Thanks for this great library.

I've found a minor edge case issue. I currently handle it in the calling code, but it would be nice to take care of it in the library.

Currently If pollutant concentration is outside of the lookup table range iaqi() function will crash with IndexError.

This PR fixes it. If the concentration is lower or higher than the range defined in the look up table, the function will return lowest or highest AQI value from the table accordingly.

Please let me know what you think about these changes.

Thanks.

Andrii